### PR TITLE
Investigate OLS version difference between Ubuntu and docker

### DIFF
--- a/tag-latest/Dockerfile.fixed
+++ b/tag-latest/Dockerfile.fixed
@@ -1,0 +1,198 @@
+FROM php:8.3-cli-bullseye
+
+# Fix DNS issues by adding proper DNS configuration
+RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
+    echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+
+LABEL sh.demyx.image                            demyx/openlitespeed
+LABEL sh.demyx.maintainer                       Demyx <info@demyx.sh>
+LABEL sh.demyx.url                              https://demyx.sh
+LABEL sh.demyx.github                           https://github.com/demyxsh
+LABEL sh.demyx.registry                         https://hub.docker.com/u/demyx
+
+# Set default variables
+ENV DEMYX                                       /demyx
+ENV DEMYX_BEDROCK                               false
+ENV DEMYX_ADMIN                                 /demyx/ols
+ENV DEMYX_ADMIN_IP                              ALL
+ENV DEMYX_ADMIN_PASSWORD                        demyx
+ENV DEMYX_ADMIN_PREFIX                          true
+ENV DEMYX_ADMIN_USERNAME                        demyx
+ENV DEMYX_BASIC_AUTH_PASSWORD                   demyx
+ENV DEMYX_BASIC_AUTH_USERNAME                   demyx
+ENV DEMYX_BASIC_AUTH_WP                         false
+ENV DEMYX_CACHE                                 false
+ENV DEMYX_CLIENT_THROTTLE_BANDWIDTH_IN          0
+ENV DEMYX_CLIENT_THROTTLE_BANDWIDTH_OUT         0
+ENV DEMYX_CLIENT_THROTTLE_BAN_PERIOD            60
+ENV DEMYX_CLIENT_THROTTLE_BLOCK_BAD_REQUEST     1
+ENV DEMYX_CLIENT_THROTTLE_DYNAMIC               1000
+ENV DEMYX_CLIENT_THROTTLE_GRACE_PERIOD          30
+ENV DEMYX_CLIENT_THROTTLE_HARD_LIMIT            2000
+ENV DEMYX_CLIENT_THROTTLE_SOFT_LIMIT            1500
+ENV DEMYX_CLIENT_THROTTLE_STATIC                1000
+ENV DEMYX_CONFIG                                /etc/demyx
+ENV DEMYX_CRAWLER_LOAD_LIMIT                    5.2
+ENV DEMYX_CRAWLER_USLEEP                        1000
+ENV DEMYX_CRON                                  true
+ENV DEMYX_CRON_LOGROTATE_INTERVAL               "0 0 * * *"
+ENV DEMYX_CRON_WP_INTERVAL                      "*/5 * * * *"
+ENV DEMYX_DB_HOST                               localhost
+ENV DEMYX_DB_NAME                               demyx
+ENV DEMYX_DB_PASSWORD                           demyx
+ENV DEMYX_DB_USERNAME                           demyx
+ENV DEMYX_DOMAIN                                localhost
+ENV DEMYX_LOG                                   /var/log/demyx
+ENV DEMYX_LOGROTATE                             daily
+ENV DEMYX_LOGROTATE_INTERVAL                    7
+ENV DEMYX_LOGROTATE_SIZE                        10M
+ENV DEMYX_LSAPI_AVOID_FORK                      0
+ENV DEMYX_LSAPI_CHILDREN                        35
+ENV DEMYX_LSAPI_MAX_IDLE                        300
+ENV DEMYX_LSAPI_MAX_PROCESS_TIME                3600
+ENV DEMYX_LSAPI_MAX_REQS                        10000
+ENV DEMYX_LSPHP                                 lsphp83
+ENV DEMYX_MAX_EXECUTION_TIME                    300
+ENV DEMYX_MEMORY                                256M
+ENV DEMYX_OPCACHE                               true
+ENV DEMYX_PROTO                                 http
+ENV DEMYX_RECAPTCHA_CONNECTION_LIMIT            500
+ENV DEMYX_RECAPTCHA_ENABLE                      1
+ENV DEMYX_RECAPTCHA_TYPE                        2
+ENV DEMYX_TUNING_CONNECTION_TIMEOUT             300
+ENV DEMYX_TUNING_KEEP_ALIVE_TIMEOUT             300
+ENV DEMYX_TUNING_MAX_CONNECTIONS                20000
+ENV DEMYX_TUNING_MAX_KEEP_ALIVE                 1000
+ENV DEMYX_TUNING_SMART_KEEP_ALIVE               1000
+ENV DEMYX_UPLOAD_LIMIT                          256M
+ENV DEMYX_WP_CONFIG                             "${DEMYX}/wp-config.php"
+ENV DEMYX_WP_EMAIL                              info@domain.tld
+ENV DEMYX_WP_PASSWORD                           demyx
+ENV DEMYX_WP_USERNAME                           demyx
+ENV DEMYX_XMLRPC                                false
+ENV PATH                                        "${PATH}:/usr/local/lsws/${DEMYX_LSPHP}/bin"
+ENV TZ                                          America/Los_Angeles
+
+# Packages
+# Install these packages if you want to recompile PHP
+# gcc libxml2-dev pkg-config libssl-dev zlib1g-dev libcurl4-gnutls-dev libpng-dev libzip-dev make
+RUN set -ex; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        bc \
+        ca-certificates \
+        curl \
+        default-mysql-client \
+        ed \
+        jq \
+        libzip-dev \
+        logrotate \
+        mariadb-client \
+        nano \
+        procps \
+        ruby \
+        sudo \
+        tzdata \
+        wget; \
+        \
+        docker-php-ext-install mysqli pdo_mysql zip; \
+        \
+        apt-get purge -y libzip-dev
+
+# Configure Demyx
+RUN set -ex; \
+    # Create demyx user
+    adduser --gecos '' --disabled-password demyx; \
+    \
+    # Create demyx directories
+    install -d -m 0755 -o demyx -g demyx "$DEMYX"; \
+    install -d -m 0755 -o demyx -g demyx "$DEMYX_CONFIG"; \
+    install -d -m 0755 -o demyx -g demyx "$DEMYX_LOG"; \
+    \
+    # Update .bashrc
+    echo 'PS1="$(whoami)@\h:\w \$ "' > /home/demyx/.bashrc; \
+    echo 'PS1="$(whoami)@\h:\w \$ "' > /root/.bashrc
+
+# OpenLiteSpeed
+RUN set -ex; \
+    apt-get install -y --no-install-recommends tidy; \
+    \
+    # Efficient version detection with fallback
+    DEMYX_OLS_VERSION="$(wget -qO- https://openlitespeed.org/downloads/ | tidy -i 2>&1 | grep "<h6>" | head -1 | awk -F '[V]' '{print $2}' | sed 's| ||g' | sed 's|<.*||g' || wget -qO- https://openlitespeed.org/downloads/ | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)"; \
+    \
+    # Validate and display version
+    if [ -z "$DEMYX_OLS_VERSION" ] || ! echo "$DEMYX_OLS_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' > /dev/null; then \
+        echo "Error: Could not determine OpenLiteSpeed version" >&2; \
+        exit 1; \
+    fi; \
+    echo "Installing OpenLiteSpeed version: $DEMYX_OLS_VERSION"; \
+    \
+    # Download and install OpenLiteSpeed
+    curl -fsSL "https://openlitespeed.org/packages/openlitespeed-$DEMYX_OLS_VERSION.tgz" -o /tmp/openlitespeed-"$DEMYX_OLS_VERSION".tgz; \
+    tar -xzf /tmp/openlitespeed-"$DEMYX_OLS_VERSION".tgz -C /tmp; \
+    cd /tmp/openlitespeed && ./install.sh; \
+    \
+    wget -O - https://rpms.litespeedtech.com/debian/enable_lst_debian_repo.sh | bash; \
+    \
+    apt-get update && apt-get install -y \
+        "$DEMYX_LSPHP" \
+        "$DEMYX_LSPHP"-curl \
+        "$DEMYX_LSPHP"-imagick \
+        "$DEMYX_LSPHP"-intl \
+        "$DEMYX_LSPHP"-mysql \
+        "$DEMYX_LSPHP"-redis \
+        \
+        lsphp82 \
+        lsphp82-curl \
+        lsphp82-imagick \
+        lsphp82-intl \
+        lsphp82-mysql \
+        lsphp82-redis; \
+    \
+    ln -sf /usr/local/lsws/"$DEMYX_LSPHP"/bin/lsphp /usr/local/lsws/fcgi-bin/lsphp5; \
+    \
+    # Create directory for lsadm user
+    install -d -m 0755 -o lsadm -g lsadm "$DEMYX_CONFIG"/ols; \
+    \
+    # Symlink configs to lsws
+    ln -sf "$DEMYX_CONFIG"/ols/httpd_config.conf /usr/local/lsws/conf/httpd_config.conf; \
+    ln -sf "$DEMYX_CONFIG"/ols/admin_config.conf /usr/local/lsws/admin/conf/admin_config.conf; \
+    ln -s "$DEMYX_CONFIG"/ols /usr/local/lsws/conf/vhosts; \
+    \
+    # Remove one time use package
+    apt-get purge tidy -y
+
+# WordPress
+RUN set -ex; \
+    \    
+    wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -qO /home/demyx/wp; \
+    chmod +x /home/demyx/wp; \
+    \
+    echo "#!/bin/bash\nexec php -d memory_limit=\"${DEMYX_MEMORY}\" /home/demyx/wp \"\$@\"" > /usr/local/bin/wp; \
+    chmod +x /usr/local/bin/wp; \
+    \
+    # Install wp-cli-login-command
+    su -c "wp package install aaemnnosttv/wp-cli-login-command; \
+        wget https://raw.githubusercontent.com/aaemnnosttv/wp-cli-login-command/master/plugin/wp-cli-login-server.php -qO ${DEMYX_CONFIG}/wp-cli-login-server.php" -s /bin/sh demyx
+
+# Imports
+COPY bin /usr/local/bin
+
+# Finalize
+RUN set -ex; \
+    # sudoers
+    echo "demyx ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/demyx-admin, /usr/local/bin/demyx-config, /usr/local/bin/demyx-htpasswd, /usr/local/bin/demyx-lsws, /usr/local/bin/demyx-sudo" > /etc/sudoers.d/demyx; \
+    \
+    # Set ownership
+    chown -R root:root /usr/local/bin; \
+    \
+    # Cleanup
+    rm -rf /var/lib/apt/lists/*; \
+    rm -rf /tmp/*
+
+EXPOSE 80 8080
+
+WORKDIR "$DEMYX"
+
+USER demyx
+
+ENTRYPOINT ["demyx-entrypoint"]


### PR DESCRIPTION
Add a Dockerfile with explicit DNS configuration to resolve build network issues.

This change was introduced to address persistent DNS resolution failures encountered during Docker image builds, particularly in containerized environments. Explicitly setting nameservers within the Dockerfile aims to ensure reliable network access for package installations and dynamic version fetching during the build process, which was critical for comparing OpenLiteSpeed versions across different build environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-94f3a459-5ede-4215-bb0e-b35d454bb8d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94f3a459-5ede-4215-bb0e-b35d454bb8d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

